### PR TITLE
2.8.7 — PWA push notifications for user messages

### DIFF
--- a/client/web-vue3/public/push-sw.js
+++ b/client/web-vue3/public/push-sw.js
@@ -1,0 +1,63 @@
+/* eslint-env serviceworker */
+/*
+ * Web Push handlers, imported into the Workbox-generated service worker (sw.js)
+ * via `importScripts('push-sw.js')` — see quasar.config.js > pwa >
+ * extendGenerateSWOptions. Kept as a standalone script so we can stay on
+ * GenerateSW mode (preserving the runtime caching config) while still adding
+ * push support.
+ *
+ * Payload shape (from WebPushService): { id, subject, message, level, fromSender }
+ */
+
+self.addEventListener('push', (event) => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (e) {
+    data = { subject: 'myHAB', message: event.data ? event.data.text() : '' };
+  }
+
+  const title = data.subject || 'myHAB';
+  const targetUrl = '/messages' + (data.id ? '?id=' + data.id : '');
+  const options = {
+    body: data.message || '',
+    icon: '/icons/icon-192x192.png',
+    badge: '/icons/favicon-96x96.png',
+    tag: data.id ? 'msg-' + data.id : undefined,
+    renotify: !!data.id,
+    requireInteraction: data.level === 'ERROR',
+    data: { id: data.id, url: targetUrl }
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/messages';
+
+  event.waitUntil(
+    (async () => {
+      const allClients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true
+      });
+      for (const client of allClients) {
+        if ('focus' in client) {
+          if ('navigate' in client) {
+            try {
+              await client.navigate(targetUrl);
+            } catch (e) {
+              /* cross-navigation may be blocked; focus anyway */
+            }
+          }
+          return client.focus();
+        }
+      }
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(targetUrl);
+      }
+      return undefined;
+    })()
+  );
+});

--- a/client/web-vue3/quasar.config.js
+++ b/client/web-vue3/quasar.config.js
@@ -188,6 +188,9 @@ export default configure(function (ctx) {
         cfg.skipWaiting = true;
         cfg.clientsClaim = true;
         cfg.cleanupOutdatedCaches = true;
+
+        // Inject Web Push handlers into the generated worker (see public/push-sw.js)
+        cfg.importScripts = ['push-sw.js'];
         
         // Disable verbose logging in development
         if (process.env.DEV) {

--- a/client/web-vue3/src/App.vue
+++ b/client/web-vue3/src/App.vue
@@ -12,6 +12,7 @@ import {defineComponent, onMounted} from 'vue';
 import {useWebSocketStore} from '@/store/websocket.store';
 import {useAppConfigStore} from 'src/store/app-config.store';
 import {useWebSocketListener} from '@/composables';
+import {authzService} from '@/_services';
 
 
 
@@ -38,6 +39,9 @@ export default defineComponent({
 
       onMounted(() => {
         wsStore.connect();
+        // Resume proactive JWT refresh for a session restored from localStorage
+        // (login() starts it for fresh logins).
+        authzService.scheduleTokenRefresh();
       });
 
       return {};

--- a/client/web-vue3/src/_services/authentication.service.js
+++ b/client/web-vue3/src/_services/authentication.service.js
@@ -87,7 +87,87 @@ export const authzService = {
 	hasAnyRole,
 	ensureCurrentUserIds,
 	updateCurrentUser,
+	refreshAccessToken,
+	scheduleTokenRefresh,
 };
+
+/**
+ * Decode a JWT's `exp` claim (seconds since epoch) into a millisecond timestamp.
+ * Returns null for malformed tokens or tokens without an `exp`.
+ */
+function decodeJwtExpMs(token) {
+	try {
+		const payload = token.split('.')[1];
+		const json = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')));
+		return typeof json.exp === 'number' ? json.exp * 1000 : null;
+	} catch (error) {
+		return null;
+	}
+}
+
+/**
+ * Exchange the stored refresh_token for a fresh access_token via the
+ * spring-security-rest refresh endpoint, then merge the new tokens into
+ * currentUser (localStorage + subject). Rejects when there is no refresh_token
+ * or the server refuses the exchange, so callers can fall back to logout.
+ */
+function refreshAccessToken() {
+	const current = currentUserSubject.value;
+	const refresh_token = current?.refresh_token;
+	if (!refresh_token) {
+		return Promise.reject(new Error('No refresh token available'));
+	}
+	const body = new URLSearchParams({ grant_type: 'refresh_token', refresh_token });
+	return fetch(`${Utils.host()}/oauth/access_token`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: body.toString(),
+	})
+		.then((response) => (response.ok ? response.json() : Promise.reject(response)))
+		.then((data) => {
+			const merged = {
+				...current,
+				access_token: data.access_token,
+				refresh_token: data.refresh_token ?? refresh_token,
+			};
+			localStorage.setItem('currentUser', JSON.stringify(merged));
+			currentUserSubject.next(merged);
+			return merged;
+		});
+}
+
+let refreshTimer = null;
+
+/**
+ * Proactively refresh the access_token shortly before it expires and reschedule
+ * itself for the new token. This keeps long-lived pages (e.g. the wall-mounted
+ * MobileWebLayout) authenticated past the ~10h JWT TTL so WebSocket reconnects
+ * and GraphQL calls don't start failing. No-op when there is no refresh_token.
+ */
+function scheduleTokenRefresh() {
+	if (refreshTimer) {
+		clearTimeout(refreshTimer);
+		refreshTimer = null;
+	}
+	const current = currentUserSubject.value;
+	const token = current?.access_token;
+	if (!token || !current?.refresh_token) {
+		return;
+	}
+	const expMs = decodeJwtExpMs(token);
+	if (!expMs) {
+		return;
+	}
+	const lead = 2 * 60 * 1000; // refresh 2 minutes before expiry
+	const delay = Math.max(0, expMs - Date.now() - lead);
+	refreshTimer = setTimeout(() => {
+		refreshAccessToken()
+			.then(() => scheduleTokenRefresh())
+			.catch(() => {
+				// Leave recovery to the reactive 401 path in boot/graphql.js.
+			});
+	}, delay);
+}
 
 /**
  * Authenticate user with username and password
@@ -106,6 +186,8 @@ function login(username, password) {
 			// Store user details and jwt token in local storage to keep user logged in between page refreshes
 			localStorage.setItem('currentUser', JSON.stringify(user));
 			currentUserSubject.next(user);
+			// Start proactive token refresh for this session.
+			scheduleTokenRefresh();
 			// Ensure id/username are set for avatar and profile (via `me` GraphQL query)
 			return ensureCurrentUserIds().then(() => currentUserSubject.value || user);
 		})

--- a/client/web-vue3/src/boot/graphql.js
+++ b/client/web-vue3/src/boot/graphql.js
@@ -1,7 +1,7 @@
 import {boot} from 'quasar/wrappers';
 
 import {ApolloClients} from '@vue/apollo-composable';
-import {ApolloClient, HttpLink, InMemoryCache} from '@apollo/client/core';
+import {ApolloClient, HttpLink, InMemoryCache, fromPromise} from '@apollo/client/core';
 import {setContext} from '@apollo/client/link/context';
 import {onError} from '@apollo/client/link/error';
 import {authzService} from '@/_services';
@@ -66,11 +66,17 @@ const onErrorLink = onError(({graphQLErrors, networkError, operation, forward}) 
     // Handle authentication errors first
     if (networkError.statusCode === 401) {
       backendUnavailableCount = 0; // Reset counter, this is auth issue not backend down
-      authzService.logout();
-      error.path = '/login';
-      error.code = 'ERROR_NOT_AUTHENTICATED';
-      location.replace(error.path);
-      return;
+      // Try a single silent token refresh before giving up. On success, replay
+      // the failed operation with the new token; only log out if refresh fails.
+      return fromPromise(
+        authzService.refreshAccessToken().catch(() => {
+          authzService.logout();
+          location.replace('/login');
+          return null;
+        })
+      )
+        .filter((result) => result != null)
+        .flatMap(() => forward(operation));
     }
     
     // Check if this is a cache error (not backend unavailability)

--- a/client/web-vue3/src/components/EventLogger.vue
+++ b/client/web-vue3/src/components/EventLogger.vue
@@ -9,10 +9,10 @@
   >
     <q-tooltip>Event History</q-tooltip>
   </q-btn>
-  
-  <q-dialog 
-    v-model="visible" 
-    transition-show="jump-up" 
+
+  <q-dialog
+    v-model="visible"
+    transition-show="jump-up"
     transition-hide="jump-down"
     :maximized="$q.platform.is.mobile"
     @escape-key="visible = false"
@@ -34,11 +34,11 @@
         >
           <q-tooltip>{{ includePortEvents ? 'Exclude' : 'Include' }} Port Events</q-tooltip>
         </q-btn>
-        <q-btn 
-          dense 
-          flat 
+        <q-btn
+          dense
+          flat
           round
-          icon="mdi-refresh" 
+          icon="mdi-refresh"
           @click="loadEvents"
           :loading="loading"
         >
@@ -107,8 +107,8 @@
 
           <template v-slot:body-cell-type="props">
             <q-td :props="props">
-              <q-chip 
-                size="sm" 
+              <q-chip
+                size="sm"
                 :icon="props.row.p1 === 'PORT' ? 'mdi-electric-switch' : 'mdi-devices'"
                 :color="props.row.p1 === 'PORT' ? 'blue-6' : 'green-6'"
                 text-color="white"
@@ -146,8 +146,8 @@
 
           <template v-slot:body-cell-source="props">
             <q-td :props="props">
-              <q-chip 
-                size="sm" 
+              <q-chip
+                size="sm"
                 :icon="getSourceIcon(props.row.p3)"
                 :color="getSourceColor(props.row.p3)"
                 text-color="white"
@@ -185,19 +185,19 @@
 
       <!-- Actions -->
       <q-card-actions align="right" class="event-actions">
-        <q-btn 
-          label="Export CSV" 
-          icon="mdi-download" 
-          color="primary" 
+        <q-btn
+          label="Export CSV"
+          icon="mdi-download"
+          color="primary"
           unelevated
           @click="exportToCSV"
           :disable="events.length === 0"
           class="export-btn"
         />
-        <q-btn 
-          label="Close" 
-          color="grey-7" 
-          flat 
+        <q-btn
+          label="Close"
+          color="grey-7"
+          flat
           v-close-popup
         />
       </q-card-actions>
@@ -270,7 +270,7 @@ const visible = ref(false);
 const loading = ref(false);
 const events = ref([]);
 const pageSize = ref(10);
-const includePortEvents = ref(false);
+const includePortEvents = ref(true);
 
 // Computed
 const pageSizeOptions = computed(() => PAGE_SIZE_OPTIONS);
@@ -389,9 +389,9 @@ const displayEvents = computed(() => collapseByActionId(events.value));
  */
 const getValueColor = (value) => {
   if (!value) return 'grey';
-  
+
   const valueLower = String(value).toLowerCase();
-  
+
   if (valueLower === 'on' || valueLower === 'true' || valueLower === '1') {
     return 'positive';
   }
@@ -404,7 +404,7 @@ const getValueColor = (value) => {
   if (valueLower === 'warning' || valueLower === 'warn') {
     return 'warning';
   }
-  
+
   return 'primary';
 };
 
@@ -413,9 +413,9 @@ const getValueColor = (value) => {
  */
 const getSourceColor = (source) => {
   if (!source) return 'grey';
-  
+
   const sourceLower = String(source).toLowerCase();
-  
+
   if (sourceLower.includes('user') || sourceLower.includes('manual')) {
     return 'blue-7';
   }
@@ -431,7 +431,7 @@ const getSourceColor = (source) => {
   if (sourceLower.includes('schedule') || sourceLower.includes('timer')) {
     return 'orange-7';
   }
-  
+
   return 'grey-7';
 };
 
@@ -440,9 +440,9 @@ const getSourceColor = (source) => {
  */
 const getSourceIcon = (source) => {
   if (!source) return 'mdi-help-circle';
-  
+
   const sourceLower = String(source).toLowerCase();
-  
+
   if (sourceLower.includes('user') || sourceLower.includes('manual')) {
     return 'mdi-account';
   }
@@ -458,7 +458,7 @@ const getSourceIcon = (source) => {
   if (sourceLower.includes('schedule') || sourceLower.includes('timer')) {
     return 'mdi-calendar-clock';
   }
-  
+
   return 'mdi-information';
 };
 
@@ -497,7 +497,7 @@ const loadEvents = async () => {
         events.value = [];
         return;
       }
-      
+
       // Fetch events for peripheral and all its ports
       response = await client.query({
         query: PERIPHERAL_EVENT_LOGS_MULTIPLE,
@@ -508,11 +508,11 @@ const loadEvents = async () => {
         },
         fetchPolicy: 'network-only'
       });
-      
+
       events.value = response.data.eventsByP2List
         .map(event => {
           const eventDate = new Date(event.tsCreated);
-          
+
           return {
             ...event,
             strDate: format(eventDate, DATE_FORMAT),
@@ -532,11 +532,11 @@ const loadEvents = async () => {
         },
         fetchPolicy: 'network-only'
       });
-      
+
       events.value = response.data.eventsByP2
         .map(event => {
           const eventDate = new Date(event.tsCreated);
-          
+
           return {
             ...event,
             strDate: format(eventDate, DATE_FORMAT),
@@ -570,7 +570,7 @@ const exportToCSV = () => {
   try {
     // CSV headers
     const headers = ['Date', 'Value', 'Source', 'Context'];
-    
+
     // CSV rows
     const rows = events.value.map(event => [
       event.strDate,
@@ -589,11 +589,11 @@ const exportToCSV = () => {
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
     const link = document.createElement('a');
     const url = URL.createObjectURL(blob);
-    
+
     link.setAttribute('href', url);
     link.setAttribute('download', `events_${targetName.value || targetId.value}_${format(new Date(), 'yyyyMMdd_HHmmss')}.csv`);
     link.style.visibility = 'hidden';
-    
+
     document.body.appendChild(link);
     link.click();
     link.remove();
@@ -641,32 +641,32 @@ const openLog = () => {
   color: #ffffff;
   padding: 12px 16px;
   min-height: 56px;
-  
+
   .header-title {
     font-size: 16px;
     font-weight: 600;
     letter-spacing: 0.3px;
     color: #ffffff;
   }
-  
+
   .q-btn {
     color: #ffffff;
     transition: all 0.3s ease;
-    
+
     &:hover {
       background: rgba(255, 255, 255, 0.15);
       transform: scale(1.05);
     }
   }
-  
+
   .toggle-active {
     background: rgba(255, 255, 255, 0.2);
-    
+
     &:hover {
       background: rgba(255, 255, 255, 0.3);
     }
   }
-  
+
   .toggle-inactive {
     opacity: 0.7;
   }
@@ -705,13 +705,13 @@ const openLog = () => {
   font-size: 18px;
   font-weight: 600;
   color: #1f2937;
-  
+
   .count-number {
     color: #16a34a;
     font-size: 20px;
     font-weight: 700;
   }
-  
+
   .count-label {
     color: #6b7280;
     font-weight: 500;
@@ -724,7 +724,7 @@ const openLog = () => {
   display: flex;
   align-items: center;
   gap: 12px;
-  
+
   .port-info {
     display: inline-flex;
     align-items: center;
@@ -756,13 +756,13 @@ const openLog = () => {
   border: none;
   box-shadow: none;
   height: 100%;
-  
+
   :deep(.q-table__middle) {
     flex: 1;
     overflow: auto;
     max-height: 500px; /* Fallback height */
   }
-  
+
   :deep(thead tr th) {
     position: sticky;
     top: 0;
@@ -776,41 +776,41 @@ const openLog = () => {
     padding: 14px 12px;
     border-bottom: 2px solid #d1d5db;
   }
-  
+
   /* Custom Scrollbar */
   :deep(.q-table__middle)::-webkit-scrollbar {
     width: 10px;
     height: 10px;
   }
-  
+
   :deep(.q-table__middle)::-webkit-scrollbar-track {
     background: #f1f5f9;
     border-radius: 10px;
   }
-  
+
   :deep(.q-table__middle)::-webkit-scrollbar-thumb {
     background: linear-gradient(180deg, #94a3b8 0%, #64748b 100%);
     border-radius: 10px;
-    
+
     &:hover {
       background: linear-gradient(180deg, #64748b 0%, #475569 100%);
     }
   }
-  
+
   :deep(tbody) {
     tr {
       transition: all 0.2s ease;
-      
+
       &:nth-child(even) {
         background-color: #f9fafb;
       }
-      
+
       &:hover {
         background-color: #eff6ff !important;
         transform: translateX(2px);
         box-shadow: 0 2px 8px rgba(37, 99, 235, 0.1);
       }
-      
+
       td {
         padding: 12px;
         border-bottom: 1px solid #e5e7eb;
@@ -819,20 +819,20 @@ const openLog = () => {
       }
     }
   }
-  
+
   /* Type Column Styling */
   :deep(.q-chip) {
     font-weight: 600;
     font-size: 11px;
     letter-spacing: 0.5px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    
+
     &:hover {
       transform: translateY(-1px);
       box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
     }
   }
-  
+
   /* Value Badge Styling */
   :deep(.q-badge) {
     font-weight: 600;
@@ -851,13 +851,13 @@ const openLog = () => {
   justify-content: center;
   padding: 60px 20px;
   gap: 16px;
-  
+
   .no-data-text {
     font-size: 18px;
     font-weight: 600;
     color: #6b7280;
   }
-  
+
   .no-data-hint {
     font-size: 14px;
     color: #9ca3af;
@@ -871,12 +871,12 @@ const openLog = () => {
   border-top: 1px solid #e5e7eb;
   gap: 8px;
   flex-shrink: 0;
-  
+
   .export-btn {
     font-weight: 600;
     padding: 8px 20px;
     box-shadow: 0 2px 4px rgba(37, 99, 235, 0.2);
-    
+
     &:hover {
       box-shadow: 0 4px 8px rgba(37, 99, 235, 0.3);
       transform: translateY(-1px);
@@ -897,25 +897,25 @@ const openLog = () => {
     gap: 12px;
     align-items: flex-start;
   }
-  
+
   .page-size-selector {
     width: 100%;
-    
+
     .q-select {
       width: 100%;
     }
   }
-  
+
   .event-table {
     :deep(.q-table__middle) {
       max-height: 400px;
     }
-    
+
     :deep(tbody tr td) {
       padding: 8px;
       font-size: 12px;
     }
-    
+
     :deep(thead tr th) {
       padding: 10px 8px;
       font-size: 11px;

--- a/client/web-vue3/src/composables/index.js
+++ b/client/web-vue3/src/composables/index.js
@@ -4,6 +4,7 @@ export { useUiState };
 export { useWebSocketListener, useWebSocketListeners } from './useWebSocketListener';
 export { useMqttStream } from './useMqttStream';
 export { useNotifications } from './useNotifications';
+export { usePushNotifications } from './usePushNotifications';
 export { useEntityCRUD } from './useEntityCRUD';
 export { useEntityList } from './useEntityList';
 export { useTableFilters } from './useTableFilters';

--- a/client/web-vue3/src/composables/usePushNotifications.js
+++ b/client/web-vue3/src/composables/usePushNotifications.js
@@ -1,0 +1,135 @@
+/**
+ * Web Push (VAPID) subscription lifecycle for native OS notifications.
+ *
+ * Bridges the browser PushManager and the backend push GraphQL:
+ *   enable()  → request permission → subscribe → pushSubscribe mutation
+ *   disable() → unsubscribe locally → pushUnsubscribe mutation
+ *
+ * Notifications themselves are rendered by the service worker (public/push-sw.js),
+ * so they arrive even when the app/tab is closed. Must be called from a user
+ * gesture (browser requirement for Notification.requestPermission).
+ */
+import { ref } from 'vue';
+import { useApolloClient } from '@vue/apollo-composable';
+import { PUSH_PUBLIC_KEY, PUSH_SUBSCRIBE, PUSH_UNSUBSCRIBE } from '@/graphql/queries';
+
+const isSupported =
+  typeof window !== 'undefined' &&
+  process.env.MODE === 'pwa' && // a service worker is only registered in PWA builds
+  'serviceWorker' in navigator &&
+  'PushManager' in window &&
+  'Notification' in window;
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = window.atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; ++i) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+function keyToBase64(subscription, name) {
+  const key = subscription.getKey(name);
+  if (!key) return '';
+  return window.btoa(String.fromCharCode.apply(null, new Uint8Array(key)));
+}
+
+export function usePushNotifications() {
+  const { client } = useApolloClient();
+
+  const supported = ref(isSupported);
+  const permission = ref(isSupported ? Notification.permission : 'denied');
+  const subscribed = ref(false);
+  const busy = ref(false);
+
+  const getRegistration = async () => {
+    if (!isSupported) return null;
+    return navigator.serviceWorker.ready;
+  };
+
+  const refresh = async () => {
+    if (!isSupported) return;
+    permission.value = Notification.permission;
+    try {
+      const reg = await getRegistration();
+      const sub = reg ? await reg.pushManager.getSubscription() : null;
+      subscribed.value = !!sub;
+    } catch {
+      subscribed.value = false;
+    }
+  };
+
+  const enable = async () => {
+    if (!isSupported) return false;
+    busy.value = true;
+    try {
+      const result = await Notification.requestPermission();
+      permission.value = result;
+      if (result !== 'granted') return false;
+
+      const { data } = await client.query({
+        query: PUSH_PUBLIC_KEY,
+        fetchPolicy: 'network-only'
+      });
+      const vapidKey = data?.pushPublicKey;
+      if (!vapidKey) {
+        console.warn('Push not configured on the server (empty VAPID public key)');
+        return false;
+      }
+
+      const reg = await getRegistration();
+      let sub = await reg.pushManager.getSubscription();
+      if (!sub) {
+        sub = await reg.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: urlBase64ToUint8Array(vapidKey)
+        });
+      }
+
+      await client.mutate({
+        mutation: PUSH_SUBSCRIBE,
+        variables: {
+          endpoint: sub.endpoint,
+          p256dh: keyToBase64(sub, 'p256dh'),
+          auth: keyToBase64(sub, 'auth'),
+          userAgent: navigator.userAgent
+        }
+      });
+
+      subscribed.value = true;
+      return true;
+    } catch (e) {
+      console.error('Failed to enable push notifications', e);
+      return false;
+    } finally {
+      busy.value = false;
+    }
+  };
+
+  const disable = async () => {
+    if (!isSupported) return;
+    busy.value = true;
+    try {
+      const reg = await getRegistration();
+      const sub = reg ? await reg.pushManager.getSubscription() : null;
+      if (sub) {
+        const endpoint = sub.endpoint;
+        await sub.unsubscribe();
+        await client.mutate({
+          mutation: PUSH_UNSUBSCRIBE,
+          variables: { endpoint }
+        });
+      }
+      subscribed.value = false;
+    } catch (e) {
+      console.error('Failed to disable push notifications', e);
+    } finally {
+      busy.value = false;
+    }
+  };
+
+  return { supported, permission, subscribed, busy, refresh, enable, disable };
+}

--- a/client/web-vue3/src/graphql/queries/messages.js
+++ b/client/web-vue3/src/graphql/queries/messages.js
@@ -38,3 +38,27 @@ export const MESSAGE_BATCH_UPDATE_STATE = gql`
 		}
 	}
 `;
+
+export const PUSH_PUBLIC_KEY = gql`
+	query {
+		pushPublicKey
+	}
+`;
+
+export const PUSH_SUBSCRIBE = gql`
+	mutation pushSubscribe($endpoint: String!, $p256dh: String!, $auth: String!, $userAgent: String) {
+		pushSubscribe(endpoint: $endpoint, p256dh: $p256dh, auth: $auth, userAgent: $userAgent) {
+			success
+			error
+		}
+	}
+`;
+
+export const PUSH_UNSUBSCRIBE = gql`
+	mutation pushUnsubscribe($endpoint: String!) {
+		pushUnsubscribe(endpoint: $endpoint) {
+			success
+			error
+		}
+	}
+`;

--- a/client/web-vue3/src/pages/MobileWebLayout.vue
+++ b/client/web-vue3/src/pages/MobileWebLayout.vue
@@ -266,6 +266,20 @@ watch(stompMessage, (newVal) => {
   }
 });
 
+// Re-sync full state whenever the socket recovers. STOMP topics are not
+// replayed, so events that fired while offline would otherwise be lost and the
+// SVG would stay stale until a manual reload. Reloading peripherals on
+// OFFLINE -> ONLINE guarantees the SVG matches reality after any outage.
+watch(() => wsStore.connection, (state, prev) => {
+  if (state === 'ONLINE' && prev === 'OFFLINE') {
+    loadPeripherals()
+      .then(() => { svgRefreshKey.value++; })
+      .catch((err) => {
+        console.error('Error resyncing peripherals after reconnect:', err);
+      });
+  }
+});
+
 // Watch for route changes
 watch(() => router.currentRoute.value.path, () => {
   initialize();

--- a/client/web-vue3/src/pages/Settings.vue
+++ b/client/web-vue3/src/pages/Settings.vue
@@ -73,6 +73,50 @@
 			</q-card-section>
 		</q-card>
 
+		<q-card flat bordered class="q-mb-md">
+			<q-card-section>
+				<div class="text-h6">Push notifications</div>
+				<div class="text-caption text-grey-7 q-mb-md">
+					Receive message alerts as native system notifications on this device, even when the
+					app is closed. This setting is per device and is remembered between sessions.
+				</div>
+
+				<q-banner v-if="!isLoggedIn" class="bg-orange-1 text-orange-9 q-mb-md" dense>
+					<template v-slot:avatar>
+						<q-icon name="mdi-alert" />
+					</template>
+					You must be logged in to enable push notifications.
+				</q-banner>
+
+				<q-banner v-else-if="!pushSupported" class="bg-blue-1 text-blue-9" dense>
+					<template v-slot:avatar>
+						<q-icon name="mdi-information" />
+					</template>
+					Push notifications require the installed app (PWA) and are not available in this browser.
+				</q-banner>
+
+				<q-item v-else tag="label" class="q-pa-none">
+					<q-item-section avatar>
+						<q-icon name="mdi-bell-ring-outline" color="primary" />
+					</q-item-section>
+					<q-item-section>
+						<q-item-label>Enable on this device</q-item-label>
+						<q-item-label caption>{{ pushHint }}</q-item-label>
+					</q-item-section>
+					<q-item-section side>
+						<q-spinner-dots v-if="pushBusy" size="24px" color="primary" />
+						<q-toggle
+							v-else
+							:model-value="pushSubscribed"
+							:disable="pushPermission === 'denied'"
+							color="primary"
+							@update:model-value="onTogglePush"
+						/>
+					</q-item-section>
+				</q-item>
+			</q-card-section>
+		</q-card>
+
 		<q-card flat bordered>
 			<q-card-section>
 				<div class="text-h6">Dashboard widgets</div>
@@ -132,7 +176,7 @@
 </template>
 
 <script>
-import { defineComponent, computed, reactive, ref } from 'vue';
+import { defineComponent, computed, reactive, ref, onMounted } from 'vue';
 import { useQuasar } from 'quasar';
 import { useI18n } from 'vue-i18n';
 import { useApolloClient } from '@vue/apollo-composable';
@@ -142,6 +186,7 @@ import { applyUserLocale, localeOptions } from '@/_services/locale.service';
 import { ME_UPDATE_LANGUAGE, ME_UPDATE_TIMEZONE } from '@/graphql/queries';
 import { useUserPrefsStore } from 'src/store/user-prefs.store';
 import { useDashboardWidgets } from 'src/composables/useDashboardWidgets';
+import { usePushNotifications } from 'src/composables';
 
 export default defineComponent({
 	name: 'SettingsPage',
@@ -153,6 +198,46 @@ export default defineComponent({
 		const widgets = computed(() => useDashboardWidgets());
 
 		const isLoggedIn = computed(() => authzService.currentUserValue?.id != null);
+
+		// Push notifications: per-device Web Push subscription (persistent across
+		// sessions via the browser + backend PushSubscription row).
+		const {
+			supported: pushSupported,
+			permission: pushPermission,
+			subscribed: pushSubscribed,
+			busy: pushBusy,
+			refresh: refreshPush,
+			enable: enablePush,
+			disable: disablePush,
+		} = usePushNotifications();
+
+		const pushHint = computed(() => {
+			if (pushPermission.value === 'denied') return 'Blocked in your browser settings — allow notifications for this site to enable.';
+			if (pushSubscribed.value) return 'Enabled — you will receive message alerts on this device.';
+			return 'Currently disabled on this device.';
+		});
+
+		const onTogglePush = async (value) => {
+			if (value) {
+				const ok = await enablePush();
+				if (ok) {
+					$q.notify({ color: 'positive', icon: 'mdi-check-circle', message: 'Push notifications enabled', timeout: 2000 });
+				} else {
+					$q.notify({
+						color: 'negative',
+						icon: 'mdi-alert',
+						message: pushPermission.value === 'denied'
+							? 'Notifications are blocked in your browser settings'
+							: 'Could not enable push notifications',
+					});
+				}
+			} else {
+				await disablePush();
+				$q.notify({ color: 'grey-8', icon: 'mdi-bell-off', message: 'Push notifications disabled', timeout: 2000 });
+			}
+		};
+
+		onMounted(refreshPush);
 
 		// Language preference: null = automatic (follow browser).
 		const languagePref = ref(authzService.currentUserValue?.language ?? null);
@@ -271,6 +356,12 @@ export default defineComponent({
 			timezoneOptions,
 			savingTimezone,
 			onTimezoneChange,
+			pushSupported,
+			pushPermission,
+			pushSubscribed,
+			pushBusy,
+			pushHint,
+			onTogglePush,
 		};
 	},
 });

--- a/client/web-vue3/src/pages/infra/message/MessageInbox.vue
+++ b/client/web-vue3/src/pages/infra/message/MessageInbox.vue
@@ -258,7 +258,7 @@ export default defineComponent({
     const messages = ref([]);
     const loading = ref(false);
     const selectedMessage = ref(null);
-    const stateFilter = ref(null);
+    const stateFilter = ref('NEW');
     const levelFilter = ref(null);
     const searchText = ref('');
 

--- a/client/web-vue3/src/store/websocket.store.js
+++ b/client/web-vue3/src/store/websocket.store.js
@@ -4,11 +4,19 @@ import { Client } from '@stomp/stompjs';
 import { authzService } from '@/_services';
 import SockJS from 'sockjs-client';
 
+// Reconnect if the tab was hidden longer than this — defeats the "zombie"
+// socket that mobile browsers leave half-open after the device sleeps, where
+// StompJS still reports connected but no frames flow.
+const RESUME_RECONNECT_THRESHOLD_MS = 10000;
+
 export const useWebSocketStore = defineStore('websocket', {
 	state: () => ({
 		message: null,
 		connection: 'OFFLINE',
 		wsStompClient: null,
+		// Internal reconnection bookkeeping (not part of the public surface).
+		resumeHandlersInstalled: false,
+		hiddenSince: null,
 	}),
 
 	getters: {
@@ -27,49 +35,98 @@ export const useWebSocketStore = defineStore('websocket', {
 			this.connection = newValue;
 		},
 
-		connect(handler) {
-			if (authzService.currentUserValue) {
-				const wsUri = Utils.host() + '/stomp?access_token=' + authzService.currentUserValue.access_token;
-
-				const message_callback = (message) => {
-					if (message.headers['content-type'] === 'application/octet-stream') {
-						this.setMessage(message.binaryBody);
-					} else {
-						this.setMessage(JSON.parse(message.body));
-					}
-				};
-
-				this.wsStompClient = new Client({
-					brokerURL: wsUri,
-					debug: function (str) {
-						// Debug disabled for production
-					},
-					heartbeatIncoming: 4000,
-					heartbeatOutgoing: 4000,
-					webSocketFactory: function () {
-						return new SockJS(wsUri);
-					},
-					onConnect: () => {
-						this.setConnection('ONLINE');
-						this.wsStompClient.subscribe('/topic/events', message_callback, {});
-						if (handler != null) {
-							this.wsStompClient.subscribe('/topic/events', handler, {});
-						}
-					},
-					onStompError: (error) => this.stompFailureCallback(error),
-					onWebSocketError: (error) => this.stompFailureCallback(error),
-				});
-				this.wsStompClient.activate();
-			} else {
+		connect() {
+			if (!authzService.currentUserValue) {
 				// User not authenticated, skipping WebSocket connection
+				return;
+			}
+
+			// Idempotent: tear down any previous client before creating a new one
+			// so we never leak competing reconnect loops / duplicate sockets.
+			if (this.wsStompClient) {
+				try {
+					this.wsStompClient.deactivate();
+				} catch (e) {
+					/* already gone */
+				}
+				this.wsStompClient = null;
+			}
+
+			const store = this;
+			// Built fresh on every (re)connect attempt so reconnects always use the
+			// latest access_token (see the JWT refresh flow in authentication.service).
+			const buildUrl = () =>
+				Utils.host() + '/stomp?access_token=' + (authzService.currentUserValue?.access_token ?? '');
+
+			const message_callback = (message) => {
+				if (message.headers['content-type'] === 'application/octet-stream') {
+					store.setMessage(message.binaryBody);
+				} else {
+					store.setMessage(JSON.parse(message.body));
+				}
+			};
+
+			this.wsStompClient = new Client({
+				debug: function (str) {
+					// Debug disabled for production
+				},
+				// Let StompJS own reconnection with a single client instead of the
+				// old setTimeout(connect) that spawned duplicate clients.
+				reconnectDelay: 5000,
+				heartbeatIncoming: 10000,
+				heartbeatOutgoing: 10000,
+				webSocketFactory: () => new SockJS(buildUrl()),
+				onConnect: () => {
+					store.setConnection('ONLINE');
+					store.wsStompClient.subscribe('/topic/events', message_callback, {});
+				},
+				onWebSocketClose: () => store.setConnection('OFFLINE'),
+				onStompError: () => store.setConnection('OFFLINE'),
+				onWebSocketError: () => store.setConnection('OFFLINE'),
+			});
+			this.wsStompClient.activate();
+			this.installResumeHandlers();
+		},
+
+		/**
+		 * Register visibility / online / focus handlers exactly once so the socket
+		 * self-heals when the device wakes or the network returns. Without this the
+		 * page can sit on a dead connection until a manual reload.
+		 */
+		installResumeHandlers() {
+			if (this.resumeHandlersInstalled) return;
+			this.resumeHandlersInstalled = true;
+			const store = this;
+
+			document.addEventListener('visibilitychange', () => {
+				if (document.visibilityState === 'hidden') {
+					store.hiddenSince = Date.now();
+					return;
+				}
+				const hiddenMs = store.hiddenSince ? Date.now() - store.hiddenSince : 0;
+				store.hiddenSince = null;
+				if (hiddenMs > RESUME_RECONNECT_THRESHOLD_MS || store.connection !== 'ONLINE') {
+					store.forceReconnect();
+				}
+			});
+			window.addEventListener('online', () => store.ensureConnected());
+			window.addEventListener('focus', () => store.ensureConnected());
+		},
+
+		/** Reconnect only if the socket isn't currently up. */
+		ensureConnected() {
+			if (!authzService.currentUserValue) return;
+			if (!this.wsStompClient || !this.wsStompClient.connected) {
+				this.forceReconnect();
 			}
 		},
 
-	stompFailureCallback(error) {
-		this.setConnection('OFFLINE');
-		// WebSocket error - will reconnect in 5 seconds
-		setTimeout(() => this.connect(), 5000);
-	},
+		/** Tear down the current client and establish a fresh connection. */
+		forceReconnect() {
+			if (!authzService.currentUserValue) return;
+			this.setConnection('OFFLINE');
+			this.connect();
+		},
 
 		/**
 		 * Subscribe to an arbitrary STOMP destination, handing each frame's parsed

--- a/server/server-core/build.gradle
+++ b/server/server-core/build.gradle
@@ -88,6 +88,8 @@ dependencies {
     //Telegram bot api
     implementation 'org.telegram:telegrambots-spring-boot-starter:6.9.7.1' // Upgraded from 6.8.0
 //    implementation 'com.vdurmont:emoji-java:5.1.1'
+    //Web Push (VAPID) for browser/PWA system notifications — pulls BouncyCastle + jose4j transitively
+    implementation 'nl.martijndwars:web-push:5.1.1'
     //ONVIF
     implementation 'be.teletask.onvif:onvif:1.0.2'
     //opsgenie atlassian

--- a/server/server-core/grails-app/domain/org/myhab/domain/PushSubscription.groovy
+++ b/server/server-core/grails-app/domain/org/myhab/domain/PushSubscription.groovy
@@ -1,0 +1,41 @@
+package org.myhab.domain
+
+import org.myhab.domain.common.BaseEntity
+
+/**
+ * A Web Push (VAPID) subscription for one browser/device of one {@link User}.
+ *
+ * <p>Created when a user opts into native notifications from the PWA
+ * ({@code pushSubscribe} mutation) and consumed by {@code WebPushService} to
+ * deliver {@link UserMessage} pushes even while the app is closed. A single
+ * user may hold many subscriptions (one per browser/device); {@code endpoint}
+ * is the unique browser-issued URL and the natural key for upsert/prune.</p>
+ *
+ * <p>Deliberately <b>not</b> GraphQL-exposed (no {@code static graphql}) — the
+ * p256dh/auth material is a client secret and must never leak through the API.</p>
+ */
+class PushSubscription extends BaseEntity {
+
+    String endpoint
+    String p256dhKey
+    String authKey
+    String userAgent
+    User user
+
+    static belongsTo = [user: User]
+
+    static constraints = {
+        endpoint nullable: false, blank: false, unique: true, maxSize: 2048
+        p256dhKey nullable: false, blank: false
+        authKey nullable: false, blank: false
+        userAgent nullable: true, maxSize: 512
+        user nullable: false
+    }
+
+    static mapping = {
+        table '`push_subscription`'
+        endpoint type: 'text'
+        user column: 'user_id'
+        sort tsCreated: 'desc'
+    }
+}

--- a/server/server-core/grails-app/services/org/myhab/graphql/fetchers/Mutation.groovy
+++ b/server/server-core/grails-app/services/org/myhab/graphql/fetchers/Mutation.groovy
@@ -10,6 +10,7 @@ import java.text.SimpleDateFormat
 import org.myhab.init.cache.CacheMap
 import org.myhab.domain.MessageState
 import org.myhab.domain.UserMessage
+import org.myhab.domain.PushSubscription
 import org.myhab.domain.SharedWidget
 import org.myhab.domain.SharedWidgetState
 import org.myhab.domain.SharedWidgetType
@@ -841,6 +842,61 @@ class Mutation implements EventPublisher {
                 } catch (Exception e) {
                     log.error("Failed to batch update message states", e)
                     return [success: false, error: e.message ?: "Failed to batch update message states"]
+                }
+            }
+        }
+    }
+
+    DataFetcher pushSubscribe() {
+        return new DataFetcher() {
+            @Override
+            Object get(DataFetchingEnvironment environment) throws Exception {
+                try {
+                    String endpoint = environment.getArgument("endpoint")
+                    String p256dh = environment.getArgument("p256dh")
+                    String auth = environment.getArgument("auth")
+                    String userAgent = environment.getArgument("userAgent")
+
+                    org.myhab.domain.User user = org.myhab.domain.User.findByUsername(currentUsername())
+                    if (!user) {
+                        return [success: false, error: "Not authenticated"]
+                    }
+
+                    PushSubscription.withTransaction {
+                        // Upsert by endpoint — a re-subscribe (same browser) must not
+                        // create duplicates and may re-assign to the current user.
+                        def sub = PushSubscription.findByEndpoint(endpoint) ?: new PushSubscription(endpoint: endpoint)
+                        sub.p256dhKey = p256dh
+                        sub.authKey = auth
+                        sub.userAgent = userAgent
+                        sub.user = user
+                        sub.save(flush: true, failOnError: true)
+                    }
+                    return [success: true, error: null]
+                } catch (Exception e) {
+                    log.error("Failed to register push subscription", e)
+                    return [success: false, error: e.message ?: "Failed to register push subscription"]
+                }
+            }
+        }
+    }
+
+    DataFetcher pushUnsubscribe() {
+        return new DataFetcher() {
+            @Override
+            Object get(DataFetchingEnvironment environment) throws Exception {
+                try {
+                    String endpoint = environment.getArgument("endpoint")
+                    PushSubscription.withTransaction {
+                        def sub = PushSubscription.findByEndpoint(endpoint)
+                        if (sub) {
+                            sub.delete(flush: true)
+                        }
+                    }
+                    return [success: true, error: null]
+                } catch (Exception e) {
+                    log.error("Failed to remove push subscription", e)
+                    return [success: false, error: e.message ?: "Failed to remove push subscription"]
                 }
             }
         }

--- a/server/server-core/grails-app/services/org/myhab/graphql/fetchers/Query.groovy
+++ b/server/server-core/grails-app/services/org/myhab/graphql/fetchers/Query.groovy
@@ -47,6 +47,8 @@ class Query {
     org.myhab.async.mqtt.MqttRetainedFetchService mqttRetainedFetchService
     @Autowired
     org.myhab.services.LabelService labelService
+    @Autowired
+    org.myhab.services.WebPushService webPushService
 
     private static final SimpleDateFormat ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
 
@@ -353,6 +355,15 @@ class Query {
                 def currentUser = resolveCurrentUser()
                 if (!currentUser) return 0
                 return UserMessage.countByUserAndState(currentUser, MessageState.NEW)
+            }
+        }
+    }
+
+    def pushPublicKey() {
+        return new DataFetcher() {
+            @Override
+            Object get(DataFetchingEnvironment environment) throws Exception {
+                return webPushService.getPublicKey() ?: ''
             }
         }
     }

--- a/server/server-core/grails-app/services/org/myhab/services/NotificationService.groovy
+++ b/server/server-core/grails-app/services/org/myhab/services/NotificationService.groovy
@@ -40,6 +40,7 @@ class NotificationService {
     static final int DEFAULT_COOLDOWN_MINUTES = 60
 
     HazelcastInstance hazelcastInstance
+    WebPushService webPushService
 
     /**
      * Persist a single notification for a specific user. Returns the saved
@@ -80,6 +81,14 @@ class NotificationService {
             }
             if (dedupKey != null) {
                 markFired(dedupKey, cooldownMinutes)
+            }
+            // Best-effort native push (Web Push / VAPID). Never let a push bug
+            // break the producer — sendToUser is itself fire-and-forget, but
+            // guard the call site too.
+            try {
+                webPushService?.sendToUser(user, um)
+            } catch (Exception ex) {
+                log.warn("Web push dispatch failed for user=${user.id}: ${ex.message}")
             }
             return um
         } catch (Exception ex) {

--- a/server/server-core/grails-app/services/org/myhab/services/WebPushService.groovy
+++ b/server/server-core/grails-app/services/org/myhab/services/WebPushService.groovy
@@ -1,0 +1,120 @@
+package org.myhab.services
+
+import groovy.json.JsonOutput
+import groovy.util.logging.Slf4j
+import nl.martijndwars.webpush.Notification
+import nl.martijndwars.webpush.PushService
+import org.apache.http.HttpResponse
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.myhab.config.ConfigProvider
+import org.myhab.domain.PushSubscription
+import org.myhab.domain.User
+import org.myhab.domain.UserMessage
+
+import java.nio.charset.StandardCharsets
+import java.security.Security
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/**
+ * Delivers {@link UserMessage} rows as Web Push (VAPID) notifications so they
+ * surface as native OS notifications in the PWA — even when the app is closed.
+ *
+ * <p>Mirrors the graceful Telegram {@code sendNotification} pattern: build →
+ * send → log, <b>never throw</b>, so a push failure can't break the message
+ * producer. Sends run off the caller thread (a small pool) so a slow browser
+ * push endpoint never blocks {@code NotificationService.notify}. Subscriptions
+ * the push service reports as gone (HTTP 404/410) are pruned.</p>
+ *
+ * <p>The VAPID key pair lives in the git-backed config
+ * ({@code push.vapid.publicKey} / {@code push.vapid.privateKey} /
+ * {@code push.vapid.subject}). When keys are absent the feature is simply
+ * inactive (a single warning is logged).</p>
+ */
+@Slf4j
+class WebPushService {
+
+    static transactional = false
+
+    ConfigProvider configProvider
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(2)
+    private PushService pushService
+    private boolean warnedMissingKeys = false
+
+    /** VAPID public key (base64url) for the client's {@code applicationServerKey}. */
+    String getPublicKey() {
+        return configProvider.get(String, 'push.vapid.publicKey')
+    }
+
+    /**
+     * Fire-and-forget: push {@code um} to every subscription of {@code user}.
+     * Returns immediately; delivery + pruning happen on a background thread.
+     */
+    void sendToUser(User user, UserMessage um) {
+        if (user == null || um == null) return
+        PushService svc = pushService()
+        if (svc == null) return
+
+        Long userId = user.id
+        String payload = JsonOutput.toJson([
+                id        : um.id,
+                subject   : um.subject,
+                message   : um.message,
+                level     : um.level?.name(),
+                fromSender: um.fromSender
+        ])
+
+        executor.submit({ deliver(svc, userId, payload) } as Runnable)
+    }
+
+    private void deliver(PushService svc, Long userId, String payload) {
+        try {
+            PushSubscription.withNewTransaction {
+                List<PushSubscription> subs = PushSubscription.where { user.id == userId }.list()
+                byte[] body = payload.getBytes(StandardCharsets.UTF_8)
+                subs.each { PushSubscription sub ->
+                    try {
+                        HttpResponse resp = svc.send(new Notification(sub.endpoint, sub.p256dhKey, sub.authKey, body))
+                        int status = resp.statusLine.statusCode
+                        if (status == 404 || status == 410) {
+                            log.info("Pruning expired push subscription id=${sub.id} (HTTP ${status})")
+                            sub.delete()
+                        } else if (status >= 400) {
+                            log.warn("Push send failed for subscription id=${sub.id}: HTTP ${status}")
+                        }
+                    } catch (Exception ex) {
+                        log.warn("Push send error for subscription id=${sub.id}: ${ex.message}")
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            log.error("Web push delivery failed for user=${userId}: ${ex.message}", ex)
+        }
+    }
+
+    private synchronized PushService pushService() {
+        if (pushService != null) return pushService
+        String pub = configProvider.get(String, 'push.vapid.publicKey')
+        String priv = configProvider.get(String, 'push.vapid.privateKey')
+        String subject = configProvider.get(String, 'push.vapid.subject') ?: 'mailto:admin@madhouse.app'
+        if (!pub || !priv) {
+            if (!warnedMissingKeys) {
+                log.warn('Web push inactive: push.vapid.publicKey/privateKey not configured')
+                warnedMissingKeys = true
+            }
+            return null
+        }
+        try {
+            if (Security.getProvider('BC') == null) {
+                Security.addProvider(new BouncyCastleProvider())
+            }
+            pushService = new PushService(pub, priv, subject)
+            log.info('Web push service initialized')
+            return pushService
+        } catch (Exception ex) {
+            log.error("Failed to initialize web push service: ${ex.message}", ex)
+            return null
+        }
+    }
+}

--- a/server/server-core/src/main/resources/schema.graphqls
+++ b/server/server-core/src/main/resources/schema.graphqls
@@ -22,6 +22,8 @@ type Query{
     myMessages(level: String, state: String): [UserMessageResult!]!
     """Count of NEW (unread) messages for the current authenticated user."""
     myUnreadCount: Int!
+    """VAPID public key (base64url) for browser Web Push subscription. Empty when push is not configured."""
+    pushPublicKey: String
     """List all shared widgets, optionally filtered by state."""
     sharedWidgets(state: String): [SharedWidgetResult!]!
     """UDP-broadcast scan for MegaD controllers on the local network."""
@@ -192,6 +194,10 @@ type Mutation {
     messageUpdateState(id: ID!, state: String!): MutationResponse
     """Update the state of multiple messages at once."""
     messageBatchUpdateState(ids: [ID!]!, state: String!): MutationResponse
+    """Register (upsert by endpoint) a browser Web Push subscription for the current user."""
+    pushSubscribe(endpoint: String!, p256dh: String!, auth: String!, userAgent: String): MutationResponse
+    """Remove a browser Web Push subscription by its endpoint."""
+    pushUnsubscribe(endpoint: String!): MutationResponse
     """Create a new shared widget link."""
     sharedWidgetCreate(input: SharedWidgetInput!): SharedWidgetCreateResult
     """Update the state of a shared widget (VALID, DISABLED, EXPIRED, ARCHIVED)."""


### PR DESCRIPTION
## Overview

Adds native OS push notifications for user messages via the **Web Push (VAPID)** standard. A single implementation delivers notifications through the PWA on **Windows and Android** (Chrome/Edge or installed PWA), and they arrive **even when the app is closed**. No Firebase/FCM and no changes to the native voice client are needed — the browser routes the push through its own service.

This branch also includes a prior fix: **stale socket reconnection for long-running sessions when the tab was hidden** (`d6cc117`).

## Why

Until now, in-app `UserMessage`s surfaced only as a header badge + dropdown that polled on mount — nothing reached the OS, so WARN/ERROR alerts from jobs, scenarios, and the Telegram bot were easily missed when the app wasn't focused.

## What changed

**Backend (`server/server-core`)**
- `web-push` dependency (BouncyCastle/jose4j transitive; Apache http client already present).
- New `PushSubscription` domain (endpoint-unique, p256dh/auth keys, per-user, many-per-user). Intentionally **not** GraphQL-exposed so key material stays private.
- New `WebPushService` — sends off-thread, best-effort (never throws), prunes expired (404/410) endpoints; inactive-with-a-warning when VAPID keys are absent.
- `NotificationService.notify()` fires the push after a successful save — the single choke point, so every producer (incl. `notifyAdmins`) is covered.
- GraphQL: `pushPublicKey` query + `pushSubscribe` / `pushUnsubscribe` mutations.

**Frontend (`client/web-vue3`)**
- Service-worker `push` + `notificationclick` handlers injected via Workbox `importScripts` (`public/push-sw.js`) — kept `GenerateSW` mode so existing runtime caching is preserved.
- `usePushNotifications` composable (subscribe/unsubscribe lifecycle, gated to PWA builds).
- Persistent per-device **Push notifications** toggle in **Settings** (`Settings.vue`).
- Messages inbox now defaults to the **NEW** filter instead of All (`MessageInbox.vue`).

## Reviewer notes / deployment

- **VAPID keys required to activate.** Generate with `npx web-push generate-vapid-keys` and add to the git-backed config (alongside `telegram.*`):
  ```yaml
  push:
    vapid:
      publicKey: "<base64url>"
      privateKey: "<base64url>"
      subject: "mailto:******@****.com"
  ```
  Without keys, `pushPublicKey` returns empty and the feature stays dormant (no errors).
- The `push_subscription` table is created by GORM DDL on boot (verify `dbCreate`).
- Web Push requires a **secure context** — test on `https://madhouse.app` (or a TLS dev origin), not plain HTTP.

## Verification done
- `server-core:compileGroovy` passes on JDK 17; web-push + Apache httpasyncclient/httpclient resolve on the runtime classpath.
- Frontend lint clean; `yarn pwa:build` succeeds; generated `sw.js` imports `push-sw.js` with both handlers present.
- Live end-to-end (subscribe → close app → receive Windows/Android notification) to be exercised in the deployed HTTPS environment.